### PR TITLE
Add Intent and Localization for GetConnectionStatus Shortcut

### DIFF
--- a/Source/Localization/Base.lproj/Intents.intentdefinition
+++ b/Source/Localization/Base.lproj/Intents.intentdefinition
@@ -162,6 +162,8 @@
 				</array>
 				<key>INIntentResponseLastParameterTag</key>
 				<integer>6</integer>
+				<key>INIntentResponseOutput</key>
+				<string>status</string>
 				<key>INIntentResponseParameters</key>
 				<array>
 					<dict>

--- a/Source/Localization/Base.lproj/Intents.intentdefinition
+++ b/Source/Localization/Base.lproj/Intents.intentdefinition
@@ -112,6 +112,83 @@
 			<key>INIntentVerb</key>
 			<string>Do</string>
 		</dict>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>generic</string>
+			<key>INIntentConfigurable</key>
+			<true/>
+			<key>INIntentDescriptionID</key>
+			<string>JOCERT</string>
+			<key>INIntentIneligibleForSuggestions</key>
+			<true/>
+			<key>INIntentManagedParameterCombinations</key>
+			<dict>
+				<key></key>
+				<dict>
+					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
+					<true/>
+					<key>INIntentParameterCombinationTitle</key>
+					<string>Get ProtonVPN Connection Status</string>
+					<key>INIntentParameterCombinationTitleID</key>
+					<string>hIcJsr</string>
+					<key>INIntentParameterCombinationUpdatesLinked</key>
+					<true/>
+				</dict>
+			</dict>
+			<key>INIntentName</key>
+			<string>GetConnectionStatus</string>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeConciseFormatString</key>
+						<string>${status}</string>
+						<key>INIntentResponseCodeConciseFormatStringID</key>
+						<string>NzUfmp</string>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>${status}</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>ZqjXZN</string>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+					</dict>
+				</array>
+				<key>INIntentResponseLastParameterTag</key>
+				<integer>6</integer>
+				<key>INIntentResponseParameters</key>
+				<array>
+					<dict>
+						<key>INIntentResponseParameterDisplayName</key>
+						<string>Status</string>
+						<key>INIntentResponseParameterDisplayNameID</key>
+						<string>ujOFps</string>
+						<key>INIntentResponseParameterDisplayPriority</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterName</key>
+						<string>status</string>
+						<key>INIntentResponseParameterTag</key>
+						<integer>5</integer>
+						<key>INIntentResponseParameterType</key>
+						<string>String</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentTitle</key>
+			<string>Get ProtonVPN Connection Status</string>
+			<key>INIntentTitleID</key>
+			<string>2LMbbw</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentVerb</key>
+			<string>Do</string>
+		</dict>
 	</array>
 	<key>INTypes</key>
 	<array/>

--- a/Source/Localization/en.lproj/Intents.strings
+++ b/Source/Localization/en.lproj/Intents.strings
@@ -10,3 +10,8 @@
 
 "ksQcRb" = "Disconnect from ProtonVPN";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Status";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/en.lproj/Localizable.strings
+++ b/Source/Localization/en.lproj/Localizable.strings
@@ -586,6 +586,7 @@
 "_extensions" = "Extensions";
 "_widget" = "iOS Widget";
 "_log_in_to_use_widget" = "Please log in to get started";
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 // Report bug
 "_report_attachments" = "Attachments";

--- a/Source/Localization/en.lproj/Localizable.strings
+++ b/Source/Localization/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
 "_delete" = "Delete";
 "_disconnect" = "Disconnect";
 "_disconnected" = "Disconnected";
+"_disconnecting" = "Disconnecting";
 "_done" = "Done";
 "_edit" = "Edit";
 "_ok" = "OK";

--- a/Source/Localization/es-MX.lproj/Intents.strings
+++ b/Source/Localization/es-MX.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Conexión rápida";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Estado";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/es-MX.lproj/Localizable.strings
+++ b/Source/Localization/es-MX.lproj/Localizable.strings
@@ -230,6 +230,8 @@
 /* (No Comment) */
 "_disconnected" = "Desconectado";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Descubrir la app";
 
@@ -1349,6 +1351,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "Conexión VPN activa";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Su dispositivo no pudo terminar una sesión VPN anterior. Necesitará reiniciar su dispositivo antes de establecer una conexión VPN nueva.";

--- a/Source/Localization/es.lproj/Intents.strings
+++ b/Source/Localization/es.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Conexión rápida";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Estado";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/es.lproj/Localizable.strings
+++ b/Source/Localization/es.lproj/Localizable.strings
@@ -230,6 +230,8 @@
 /* (No Comment) */
 "_disconnected" = "Desconectado";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Descubre la aplicación";
 
@@ -1349,6 +1351,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "Conexión VPN activa";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Su dispositivo no pudo finalizar una sesión VPN anterior. Necesitarás reiniciar tu dispositivo antes de establecer una nueva conexión VPN.";

--- a/Source/Localization/fr.lproj/Intents.strings
+++ b/Source/Localization/fr.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Connexion rapide";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Statut";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/fr.lproj/Localizable.strings
+++ b/Source/Localization/fr.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 /* (No Comment) */
 "_disconnected" = "Déconnecté";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Découvrez l'application";
 
@@ -1382,6 +1384,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "Connexion VPN active";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Votre appareil n'a pas pu terminer la session VPN précédente. Vous devrez redémarrer votre appareil avant de pouvoir établir une nouvelle connexion VPN.";

--- a/Source/Localization/it.lproj/Intents.strings
+++ b/Source/Localization/it.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Connessione rapida";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Stato";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/it.lproj/Localizable.strings
+++ b/Source/Localization/it.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 /* (No Comment) */
 "_disconnected" = "Disconnesso";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Scopri l'app";
 
@@ -1382,6 +1384,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "Connessione VPN attiva";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Il dispositivo non è riuscito a terminare una sessione VPN precedente. Sarà necessario riavviare il dispositivo prima di poter stabilire una nuova connessione VPN.";

--- a/Source/Localization/nl.lproj/Intents.strings
+++ b/Source/Localization/nl.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Snel Verbinden";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Status";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/nl.lproj/Localizable.strings
+++ b/Source/Localization/nl.lproj/Localizable.strings
@@ -230,6 +230,8 @@
 /* (No Comment) */
 "_disconnected" = "Niet verbonden";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Ontdek de app";
 
@@ -1349,6 +1351,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "VPN-verbinding actief";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Uw apparaat kon een eerdere VPN-sessie niet beëindigen. U moet uw apparaat herstarten voordat u een nieuwe VPN-verbinding kunt aanmaken.";

--- a/Source/Localization/pl.lproj/Intents.strings
+++ b/Source/Localization/pl.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Szybkie połączenie";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Status";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/pl.lproj/Localizable.strings
+++ b/Source/Localization/pl.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 /* (No Comment) */
 "_disconnected" = "Rozłączono";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Poznaj aplikację";
 
@@ -1382,6 +1384,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "Połączenie VPN jest aktywne";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Twoje urządzenie nie zakończyło poprawnie poprzedniej sesji VPN. Musisz uruchomić ponownie urządzenie, zanim będziesz mógł nawiązać nowe połączenie.";

--- a/Source/Localization/pt-BR.lproj/Intents.strings
+++ b/Source/Localization/pt-BR.lproj/Intents.strings
@@ -16,3 +16,8 @@
 /* (No Comment) */
 "Ya0ZRy" = "Conexão rápida";
 
+"2LMbbw" = "Get ProtonVPN Connection Status";
+
+"ujOFps" = "Status";
+
+"hIcJsr" = "Get ProtonVPN Connection Status";

--- a/Source/Localization/pt-BR.lproj/Localizable.strings
+++ b/Source/Localization/pt-BR.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 /* (No Comment) */
 "_disconnected" = "Desconectado";
 
+"_disconnecting" = "Disconnecting";
+
 /* (No Comment) */
 "_discover_the_app" = "Conheça o aplicativo";
 
@@ -1382,6 +1384,8 @@
 
 /* (No Comment) */
 "_vpn_connection_active" = "Conexão VPN ativa";
+
+"_vpnstatus_not_loggedin" = "You are not logged in to ProtonVPN. Open the ProtonVPN app and sign in.";
 
 /* (No Comment) */
 "_vpn_stuck_disconnecting_body" = "Seu dispositivo não conseguiu encerrar a sessão da VPN anterior. Você precisará reiniciar seu dispositivo antes de estabelecer uma nova conexão VPN.";

--- a/Source/LocalizedString.swift
+++ b/Source/LocalizedString.swift
@@ -30,6 +30,7 @@ public class LocalizedString {
     public static let delete = NSLocalizedString("_delete")
     public static let disconnect = NSLocalizedString("_disconnect")
     public static let disconnected = NSLocalizedString("_disconnected")
+    public static let disconnecting = NSLocalizedString("_disconnecting")
     public static let done = NSLocalizedString("_done")
     public static let edit = NSLocalizedString("_edit")
     public static let ok = NSLocalizedString("_ok")

--- a/Source/LocalizedString.swift
+++ b/Source/LocalizedString.swift
@@ -537,6 +537,7 @@ public class LocalizedString {
     public static let extensions = NSLocalizedString("_extensions")
     public static let widget = NSLocalizedString("_widget")
     public static let logInToUseWidget = NSLocalizedString("_log_in_to_use_widget")
+    public static let vpnStatusNotLoggedIn = NSLocalizedString("_vpnstatus_not_loggedin")
     
     // MARK: - Report bugs
     public static let reportAttachments = NSLocalizedString("_report_attachments")


### PR DESCRIPTION
Will be followed up by supporting pull request to https://github.com/ProtonVPN/ios-app.

New Shortcut:
`GetConnectionStatus() -> Localized String of VpnGateway.ConnectionStatus enum`

Purpose:
Allow users to determine ProtonVPN's connection state in SiriShortcuts